### PR TITLE
Hide unknown block/biome type warnings by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 ## [2.0.2] - 2024-01-07
 
-### Updated
+### Added
 
 - Added support for Minecraft 1.20.3+
 
   Minecraft 1.20.3 renamed the `grass` block type to `short_grass`.
+
+### Changed
+
 - Updated [Leaflet](https://leafletjs.com/) to 1.9.4
 - Updated attribution URL to https://github.com/neocturne/MinedMap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Without `--verbose`, only a single warning is printed at the end of
+  processing for unknown block/biome types, rather than once for every
+  section where such a block/biome is encountered.
+
 ## [2.0.2] - 2024-01-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
 dependencies = [
  "anstream",
  "anstyle",
@@ -231,34 +231,28 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.17"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "either"
@@ -473,15 +467,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+checksum = "81157dde2fd4ad2b45ea3a4bb47b8193b52a6346b678840d91d80d3c2cd166c5"
 dependencies = [
  "cmake",
  "libc",
@@ -713,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -784,9 +778,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -802,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/world/chunk.rs
+++ b/src/world/chunk.rs
@@ -50,39 +50,6 @@ pub enum Chunk<'a> {
 	Empty,
 }
 
-/// Inner data structure of [SectionIter]
-#[derive(Debug, Clone)]
-enum SectionIterInner<'a> {
-	/// Iterator over sections of [Chunk::V1_18]
-	V1_18 {
-		/// Inner iterator into section map
-		iter: btree_map::Iter<'a, SectionY, (SectionV1_13<'a>, BiomesV1_18<'a>, BlockLight<'a>)>,
-	},
-	/// Iterator over sections of [Chunk::V1_13]
-	V1_13 {
-		/// Inner iterator into section map
-		iter: btree_map::Iter<'a, SectionY, (SectionV1_13<'a>, BlockLight<'a>)>,
-		/// Chunk biome data
-		biomes: &'a BiomesV0<'a>,
-	},
-	/// Iterator over sections of [Chunk::V0]
-	V0 {
-		/// Inner iterator into section map
-		iter: btree_map::Iter<'a, SectionY, (SectionV0<'a>, BlockLight<'a>)>,
-		/// Chunk biome data
-		biomes: &'a BiomesV0<'a>,
-	},
-	/// Empty iterator over an unpopulated chunk ([Chunk::Empty])
-	Empty,
-}
-
-/// Iterator over the sections of a [Chunk]
-#[derive(Debug, Clone)]
-pub struct SectionIter<'a> {
-	/// Inner iterator enum
-	inner: SectionIterInner<'a>,
-}
-
 impl<'a> Chunk<'a> {
 	/// Creates a new [Chunk] from a deserialized [de::Chunk]
 	pub fn new(
@@ -281,6 +248,39 @@ impl<'a, T> SectionIterTrait<'a> for T where
 		+ ExactSizeIterator
 		+ FusedIterator
 {
+}
+
+/// Inner data structure of [SectionIter]
+#[derive(Debug, Clone)]
+enum SectionIterInner<'a> {
+	/// Iterator over sections of [Chunk::V1_18]
+	V1_18 {
+		/// Inner iterator into section map
+		iter: btree_map::Iter<'a, SectionY, (SectionV1_13<'a>, BiomesV1_18<'a>, BlockLight<'a>)>,
+	},
+	/// Iterator over sections of [Chunk::V1_13]
+	V1_13 {
+		/// Inner iterator into section map
+		iter: btree_map::Iter<'a, SectionY, (SectionV1_13<'a>, BlockLight<'a>)>,
+		/// Chunk biome data
+		biomes: &'a BiomesV0<'a>,
+	},
+	/// Iterator over sections of [Chunk::V0]
+	V0 {
+		/// Inner iterator into section map
+		iter: btree_map::Iter<'a, SectionY, (SectionV0<'a>, BlockLight<'a>)>,
+		/// Chunk biome data
+		biomes: &'a BiomesV0<'a>,
+	},
+	/// Empty iterator over an unpopulated chunk ([Chunk::Empty])
+	Empty,
+}
+
+/// Iterator over the sections of a [Chunk]
+#[derive(Debug, Clone)]
+pub struct SectionIter<'a> {
+	/// Inner iterator enum
+	inner: SectionIterInner<'a>,
 }
 
 impl<'a> SectionIter<'a> {


### PR DESCRIPTION
While using MinedMap with modded Minecraft version is not officially
supported, it should still work reasonably well if you're okay with
custom block types being invisible and custom biomes using default
grass/color/foliage colors.

Avoid spamming the log with messages for each section in this case
without --verbose, and instead just print a single warning at the end of
processing.

Closes #41