### PR TITLE
Empty region fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fix crash due to incorrect counting in info message
+
+  The calculation of the number of skipped regions could underflow when more invalid than valid
+  regions were encountered.
+
 ## [2.1.0] - 2024-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   The calculation of the number of skipped regions could underflow when more invalid than valid
   regions were encountered.
+- Ignore empty region files instead of treating them as invalid
+
+  Minecraft generates empty region files in some cases. Just ignore them instead of printing an
+  error message every time.
 
 ## [2.1.0] - 2024-01-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +570,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "enum-map",
  "fastnbt",
  "futures-util",
  "git-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pre-release-replacements = [
 anyhow = "1.0.68"
 bincode = "1.3.3"
 clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
+enum-map = "2.7.3"
 fastnbt = "2.3.2"
 futures-util = "0.3.28"
 git-version = "0.3.5"

--- a/src/core/region_processor.rs
+++ b/src/core/region_processor.rs
@@ -337,11 +337,20 @@ impl<'a> RegionProcessor<'a> {
 			})?
 			.filter_map(|entry| entry.ok())
 			.filter(|entry| {
-				// We are only interested in regular files
-				matches!(
-					entry.file_type().map(|file_type| file_type.is_file()),
-					Ok(true)
-				)
+				(|| {
+					// We are only interested in regular files
+					let file_type = entry.file_type().ok()?;
+					if !file_type.is_file() {
+						return None;
+					}
+
+					let metadata = entry.metadata().ok()?;
+					if metadata.len() == 0 {
+						return None;
+					}
+					Some(())
+				})()
+				.is_some()
 			})
 			.filter_map(|entry| parse_region_filename(&entry.file_name()))
 			.collect())


### PR DESCRIPTION
- Ignore empty region files instead of treating them as invalid
- Fix incorrect counting of skipped regions, do not crash when there are more invalid than valid regions due to integer underflow

Fixes #52