### PR TITLE
feat: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM docker.io/library/rust:alpine AS BUILDER
 
-WORKDIR /src
+WORKDIR /build
 RUN apk update && apk add cmake build-base
 
-COPY src /src/src
-COPY crates /src/crates
-COPY Cargo.toml Cargo.lock /src
+COPY src /build/src
+COPY crates /build/crates
+COPY Cargo.toml Cargo.lock /build
 RUN cargo build -r 
 
 FROM scratch AS RUNNER
 
-COPY --from=BUILDER /src/target/release/minedmap /minedmap
+COPY --from=BUILDER /build/target/release/minedmap /minedmap
 ENTRYPOINT [ "/minedmap" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/library/rust:alpine AS BUILDER
+
+WORKDIR /src
+RUN apk update && apk add cmake build-base
+
+COPY src /src/src
+COPY crates /src/crates
+COPY Cargo.toml Cargo.lock /src
+RUN cargo build -r 
+
+FROM scratch AS RUNNER
+
+COPY --from=BUILDER /src/target/release/minedmap /minedmap
+ENTRYPOINT [ "/minedmap" ]

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -1,0 +1,2 @@
+FROM docker.io/library/nginx:alpine
+COPY viewer /usr/share/nginx/html

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -1,2 +1,3 @@
 FROM docker.io/library/nginx:alpine
 COPY viewer /usr/share/nginx/html
+# datadir should be mounted to: /usr/share/nginx/html/data


### PR DESCRIPTION
Hey! Nice project you got there :)

I'm running an MC instance in Kubernetes and wanted to scratch an itch: Bluemap is unstable af, also generates enormous files. This project is the most perfect thing. <sub>With the small exception of nether/end support.</sub>

Usage:

```
docker build -f Dockerfile -t ghcr.io/neocturne/minedmap:latest
docker build -f Dockerfile.viewer -t ghcr.io/neocturne/minedmap-viewer:latest
docker run --rm -v ./data/world:/input -v ./output:/output ghcr.io/neocturne/minedmap:latest --sign-prefix '' /input /output
docker run -it --rm -v ./output/:/usr/share/nginx/html/data -p 8080:80 ghcr.io/neocturne/minedmap-viewer:latest
```
Finally open up localhost:8080 in a browser of your choice.

