### PR TITLE
ci: include target in cache key

### DIFF
--- a/.github/workflows/MinedMap.yml
+++ b/.github/workflows/MinedMap.yml
@@ -131,6 +131,8 @@ jobs:
           targets: '${{ matrix.target }}'
 
       - uses: swatinem/rust-cache@v2
+        with:
+          key: '${{ matrix.target }}'
 
       - name: 'Build'
         shell: 'bash'


### PR DESCRIPTION
Avoid cache keys colliding between build jobs running on the same OS.