### PR TITLE
resource: add Minecraft 1.21.6 Dried Ghast block type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added support for Minecraft 1.21.5
+- Added support for Minecraft 1.21.5 to 1.21.7
 
   Added new block types and handling for changed sign text storage format.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Render beautiful maps of your [Minecraft](https://minecraft.net/) worlds!
 * Put them on a webserver and view them in your browser!
-* Compatible with unmodified Minecraft Java Edition 1.8 up to 1.21.4 (no mod installation required!)
+* Compatible with unmodified Minecraft Java Edition 1.8 up to 1.21.7 (no mod installation required!)
 * Illumination layer: the world at night
 * Fast: create a full map for a huge 3GB savegame in less than 5 minutes in single-threaded operation
 * Multi-threading support: pass `-j N` to the renderer to use `N` parallel threads for generation

--- a/crates/resource/src/block_types.rs
+++ b/crates/resource/src/block_types.rs
@@ -3509,6 +3509,16 @@ pub const BLOCK_TYPES: &[(&str, ConstBlockType)] = &[
 		},
 	),
 	(
+		"dried_ghast",
+		ConstBlockType {
+			block_color: BlockColor {
+				flags: make_bitflags!(BlockFlag::{Opaque}),
+				color: Color([179, 168, 168]),
+			},
+			sign_material: None,
+		},
+	),
+	(
 		"dried_kelp_block",
 		ConstBlockType {
 			block_color: BlockColor {

--- a/resource/blocks.json
+++ b/resource/blocks.json
@@ -720,6 +720,9 @@
 	"dragon_egg": {},
 	"dragon_head": null,
 	"dragon_wall_head": null,
+	"dried_ghast": {
+		"texture": "dried_ghast_hydration_1_top"
+	},
 	"dried_kelp_block": {
 		"texture": "dried_kelp_top"
 	},


### PR DESCRIPTION
As Minecraft 1.21.7 is a hotfix release with no new block types or biomes, it is supported as well.